### PR TITLE
Updated typographical error in artifact set name

### DIFF
--- a/data/artifacts.js
+++ b/data/artifacts.js
@@ -73,7 +73,7 @@ export const artifact_data = [
         ],
     },
     {
-        name: "bloodstained_chicalry",
+        name: "bloodstained_chivalry",
         fullname: {
             en: "Bloodstained Chivalry",
             es: "Caballería Sanguinaria",


### PR DESCRIPTION
Artifact set was named "bloodstained_chicalry", changed to "bloodstained_chivalry"